### PR TITLE
Fix parameter count in SCEditorUtility

### DIFF
--- a/Editor/Scripts/SerializedDictionaryInstanceDrawer.cs
+++ b/Editor/Scripts/SerializedDictionaryInstanceDrawer.cs
@@ -276,7 +276,7 @@ namespace AYellowpaper.SerializedCollections.Editor
 
         private (DisplayType displayType, bool canToggleListDrawer) CreateDisplaySettings(SerializedProperty property, Type type)
         {
-            bool hasCustomEditor = SCEditorUtility.HasDrawerForType(type);
+            bool hasCustomEditor = SCEditorUtility.HasDrawerForType(type, property.propertyType == SerializedPropertyType.ManagedReference);
             bool isGenericWithChildren = property.propertyType == SerializedPropertyType.Generic && property.hasVisibleChildren;
             bool isArray = property.isArray && property.propertyType != SerializedPropertyType.String;
             bool canToggleListDrawer = isArray || (isGenericWithChildren && hasCustomEditor);

--- a/Editor/Scripts/Utility/SCEditorUtility.cs
+++ b/Editor/Scripts/Utility/SCEditorUtility.cs
@@ -90,7 +90,7 @@ namespace AYellowpaper.SerializedCollections.Editor
             return settings.AlwaysShowSearch ? true : pages >= settings.PageCountForSearch;
         }
 
-        public static bool HasDrawerForType(Type type)
+        public static bool HasDrawerForType(Type type, bool isPropertyManagedReferenceType)
         {
             Type attributeUtilityType = typeof(SerializedProperty).Assembly.GetType("UnityEditor.ScriptAttributeUtility");
             if (attributeUtilityType == null)
@@ -98,7 +98,19 @@ namespace AYellowpaper.SerializedCollections.Editor
             var getDrawerMethod = attributeUtilityType.GetMethod("GetDrawerTypeForType", BindingFlags.Static | BindingFlags.NonPublic);
             if (getDrawerMethod == null)
                 return false;
-            return getDrawerMethod.Invoke(null, new object[] { type }) != null;
+
+#if UNITY_2022_3_OR_NEWER
+            if (getDrawerMethod.GetParameters().Length == 2)
+            {
+                return getDrawerMethod.Invoke(type, new object[] { type, isPropertyManagedReferenceType }) != null;
+            }
+            else
+            {
+                return getDrawerMethod.Invoke(type, new object[] { type }) != null;
+            }
+#else
+            return getDrawerMethod.Invoke(type, new object[] { type }) != null;
+#endif
         }
 
         internal static void AddGenericMenuItem(GenericMenu genericMenu, bool isOn, bool isEnabled, GUIContent content, GenericMenu.MenuFunction action)


### PR DESCRIPTION
In Unity 2022.3.25, UnityEditor.ScriptAttributeUtility.GetDrawerTypeForTypeDelegate(Type type) was changed to UnityEditor.ScriptAttributeUtility.GetDrawerTypeForTypeDelegate(Type type, bool isPropertyManagedReference).