### PR TITLE
Loading assets via guid instead of absolute paths

### DIFF
--- a/Editor/Scripts/KeyListGenerators/KeyListGeneratorSelectorWindow.cs
+++ b/Editor/Scripts/KeyListGenerators/KeyListGeneratorSelectorWindow.cs
@@ -25,7 +25,9 @@ namespace AYellowpaper.SerializedCollections.KeysGenerators
 
         private void OnEnable()
         {
-            VisualTreeAsset document = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>("Assets/Plugins/SerializedCollections/Editor/Assets/KeysGeneratorSelectorWindow.uxml");
+            //Editor/Assets/KeysGeneratorSelectorWindow.uxml
+            var assetPath = AssetDatabase.GUIDToAssetPath("681c8a924c8b1e14b9fe53bb7397ec3d");
+            VisualTreeAsset document = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(assetPath);
             var element = document.CloneTree();
             element.style.height = new StyleLength(new Length(100, LengthUnit.Percent));
             rootVisualElement.Add(element);

--- a/Editor/Scripts/SerializedDictionaryDrawer.cs
+++ b/Editor/Scripts/SerializedDictionaryDrawer.cs
@@ -35,7 +35,9 @@ namespace AYellowpaper.SerializedCollections.Editor
             {
                 if (_displayTypeToggleContent == null)
                 {
-                    var texture = AssetDatabase.LoadAssetAtPath<Texture>("Assets/Plugins/SerializedCollections/Editor/Assets/BurgerMenu@2x.png");
+                    //Editor/Assets/BurgerMenu@2x.png
+                    var assetPath = AssetDatabase.GUIDToAssetPath("8deddfed9f39d7740879d2cb0fcf7ce0");
+                    var texture = AssetDatabase.LoadAssetAtPath<Texture>(assetPath);
                     _displayTypeToggleContent = new GUIContent(texture, "Toggle to either draw existing editor or draw properties manually.");
                 }
                 return _displayTypeToggleContent;


### PR DESCRIPTION
This allows to use the key generator when the project is not imported into Assets/Plugins/SerializedDictionary. It now works with any path, even when imported as package directly via git URL.

Fixes ayellowpaper/SerializedDictionary#7